### PR TITLE
add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+---
+Checks:          '-*,clang-analyzer-core*,clang-analyzer-cplusplus*,cppcoreguidelines-*,bugprone-*,readability-*,performance-*,modernize-*,misc-*,-bugprone-suspicious-include,-readability-identifier-length,-modernize-use-trailing-return-type,-readability-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: '.*'
+SystemHeaders:   false
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@
 
 cmake_minimum_required(VERSION 3.16.3)
 
+find_program(CLANG_TIDY "clang-tidy") # REQUIRED
+if(CLANG_TIDY)
+    execute_process(COMMAND ${CLANG_TIDY} --version)
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-extra-arg=-Wno-unknown-warning-option")
+else()
+    message(WARNING "Could NOT find program 'clang-tidy'!")
+endif()
+
 macro(qsk_setup_options)
 
     option(BUILD_PEDANTIC     "Enable pedantic compile flags ( only GNU/CLANG )" OFF)
@@ -81,7 +89,7 @@ endmacro()
 ############################################################################
 
 project(QSkinny
-    LANGUAGES C CXX 
+    LANGUAGES C CXX
     HOMEPAGE_URL "https://github.com/uwerat/qskinny"
     VERSION 0.8.0)
 
@@ -169,4 +177,19 @@ endif()
 
 if(BUILD_PLAYGROUND)
     add_subdirectory(playground)
+endif()
+
+if(CLANG_TIDY)
+    file(GLOB_RECURSE EXAMPLE_FILES
+        ${CMAKE_CURRENT_LIST_DIR}/examples/*.h
+        ${CMAKE_CURRENT_LIST_DIR}/examples/*.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/examples/*.c
+        ${CMAKE_CURRENT_LIST_DIR}/examples/*.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/playground/*.h
+        ${CMAKE_CURRENT_LIST_DIR}/playground/*.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/playground/*.c
+        ${CMAKE_CURRENT_LIST_DIR}/playground/*.cpp
+    )
+
+    set_source_files_properties(${EXAMPLE_FILES} PROPERTIES SKIP_LINTING ON)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,10 @@
 
 cmake_minimum_required(VERSION 3.16.3)
 
-find_program(CLANG_TIDY "clang-tidy") # REQUIRED
-if(CLANG_TIDY)
-    execute_process(COMMAND ${CLANG_TIDY} --version)
+option(BUILD_CLANG_TIDY "Enable usage of clang-tidy" OFF)
+if(BUILD_CLANG_TIDY)
+    find_program(CLANG_TIDY "clang-tidy" REQUIRED)
     set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-extra-arg=-Wno-unknown-warning-option")
-else()
-    message(WARNING "Could NOT find program 'clang-tidy'!")
 endif()
 
 macro(qsk_setup_options)
@@ -179,7 +177,7 @@ if(BUILD_PLAYGROUND)
     add_subdirectory(playground)
 endif()
 
-if(CLANG_TIDY)
+if(BUILD_CLANG_TIDY)
     file(GLOB_RECURSE EXAMPLE_FILES
         ${CMAKE_CURRENT_LIST_DIR}/examples/*.h
         ${CMAKE_CURRENT_LIST_DIR}/examples/*.hpp

--- a/cmake/QskBuildFunctions.cmake
+++ b/cmake/QskBuildFunctions.cmake
@@ -9,14 +9,16 @@ function(qsk_add_executable target)
         qt6_add_executable(${ARGV})
 
         # we manually export our APIs to QML - might change in the future
-        set_target_properties(${target} PROPERTIES 
+        set_target_properties(${target} PROPERTIES
             QT_QML_MODULE_NO_IMPORT_SCAN 1)
     else()
         add_executable(${ARGV})
     endif()
 
     set_target_properties(${target} PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        CXX_CLANG_TIDY ""
+        )
 
 endfunction()
 
@@ -105,7 +107,7 @@ function(qsk_add_example target)
         target_link_libraries(${target} PRIVATE qskqmlexport)
     endif()
 
-    # for examples with subdirectories 
+    # for examples with subdirectories
     target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 endfunction()


### PR DESCRIPTION
```yaml
# set this to * to treat all warnings as errors
WarningsAsErrors: '*' 
```
Alternatively set it in clang-tidy's command line arguments:

```cmake
set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-extra-arg=-Wno-unknown-warning-option;--warnings-as-errors=*")
```
