### PR TITLE
enable unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@
 
 cmake_minimum_required(VERSION 3.16.3)
 
+option(BUILD_UNITY "Enable unity builds" ON)
+if(BUILD_UNITY)
+    set(CMAKE_UNITY_BUILD ON)
+endif()
+
 macro(qsk_setup_options)
 
     option(BUILD_PEDANTIC     "Enable pedantic compile flags ( only GNU/CLANG )" OFF)
@@ -81,7 +86,7 @@ endmacro()
 ############################################################################
 
 project(QSkinny
-    LANGUAGES C CXX 
+    LANGUAGES C CXX
     HOMEPAGE_URL "https://github.com/uwerat/qskinny"
     VERSION 0.8.0)
 
@@ -169,4 +174,12 @@ endif()
 
 if(BUILD_PLAYGROUND)
     add_subdirectory(playground)
+endif()
+
+if(BUILD_UNITY)
+    file(GLOB_RECURSE MOC_FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/moc_*.cpp
+    )
+
+    set_source_files_properties(${MOC_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,6 @@
 
 cmake_minimum_required(VERSION 3.16.3)
 
-option(BUILD_UNITY "Enable unity builds" ON)
-if(BUILD_UNITY)
-    set(CMAKE_UNITY_BUILD ON)
-endif()
-
 macro(qsk_setup_options)
 
     option(BUILD_PEDANTIC     "Enable pedantic compile flags ( only GNU/CLANG )" OFF)
@@ -20,6 +15,8 @@ macro(qsk_setup_options)
     option(BUILD_INPUTCONTEXT "Build virtual keyboard support" ON)
     option(BUILD_EXAMPLES     "Build qskinny examples" ON)
     option(BUILD_PLAYGROUND   "Build qskinny playground" ON)
+
+    option(BUILD_UNITY "Enable unity builds" ON)
 
     # we actually want to use cmake_dependent_option - minimum cmake version ??
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,9 @@ if(BUILD_PLAYGROUND)
 endif()
 
 if(BUILD_UNITY)
-    file(GLOB_RECURSE MOC_FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/moc_*.cpp
+    file(GLOB_RECURSE CPP_FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/*.cpp
     )
 
-    set_source_files_properties(${MOC_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    set_source_files_properties(${CPP_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 endif()

--- a/cmake/QskBuildFunctions.cmake
+++ b/cmake/QskBuildFunctions.cmake
@@ -9,7 +9,7 @@ function(qsk_add_executable target)
         qt6_add_executable(${ARGV})
 
         # we manually export our APIs to QML - might change in the future
-        set_target_properties(${target} PROPERTIES 
+        set_target_properties(${target} PROPERTIES
             QT_QML_MODULE_NO_IMPORT_SCAN 1)
     else()
         add_executable(${ARGV})
@@ -92,6 +92,8 @@ function(qsk_add_example target)
     set_target_properties(${target} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../bin )
 
+    set_target_properties(${target} PROPERTIES UNITY_BUILD OFF)
+
     target_link_libraries(${target} PRIVATE qskinny )
 
     # not all examples need this one. TODO ...
@@ -105,7 +107,7 @@ function(qsk_add_example target)
         target_link_libraries(${target} PRIVATE qskqmlexport)
     endif()
 
-    # for examples with subdirectories 
+    # for examples with subdirectories
     target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 endfunction()

--- a/cmake/QskBuildFunctions.cmake
+++ b/cmake/QskBuildFunctions.cmake
@@ -92,8 +92,6 @@ function(qsk_add_example target)
     set_target_properties(${target} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../bin )
 
-    set_target_properties(${target} PROPERTIES UNITY_BUILD OFF)
-
     target_link_libraries(${target} PRIVATE qskinny )
 
     # not all examples need this one. TODO ...

--- a/designsystems/fluent2/QskFluent2Skin.cpp
+++ b/designsystems/fluent2/QskFluent2Skin.cpp
@@ -145,10 +145,13 @@ namespace
         return static_cast< double >( value );
     }
 
+    #ifndef __rgbGray
+    #define __rgbGray
     inline constexpr QRgb rgbGray( int value, qreal opacity = 1.0 )
     {
         return qRgba( value, value, value, qRound( opacity * 255 ) );
     }
+    #endif
 
     /*
         When application code is manipulating base colors manually the colors of

--- a/designsystems/fluent2/QskFluent2Theme.cpp
+++ b/designsystems/fluent2/QskFluent2Theme.cpp
@@ -8,10 +8,13 @@
 
 namespace
 {
+    #ifndef __rgbGray
+    #define __rgbGray
     inline constexpr QRgb rgbGray( int value, qreal opacity = 1.0 )
     {
         return qRgba( value, value, value, qRound( opacity * 255 ) );
     }
+    #endif
 }
 
 QskFluent2Theme::QskFluent2Theme( QskSkin::ColorScheme colorScheme,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -537,7 +537,9 @@ set_target_properties(${target} PROPERTIES EXPORT_NAME ${PROJECT_NAME})
 set_target_properties(${target} PROPERTIES
     VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} )
 
-set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
+if(BUILD_UNITY)
+    set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
+endif()
 
 # packaging
 set(PACKAGE_NAME ${PROJECT_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -537,6 +537,8 @@ set_target_properties(${target} PROPERTIES EXPORT_NAME ${PROJECT_NAME})
 set_target_properties(${target} PROPERTIES
     VERSION ${CMAKE_PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} )
 
+set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
+
 # packaging
 set(PACKAGE_NAME ${PROJECT_NAME})
 
@@ -568,7 +570,7 @@ install(EXPORT ${PACKAGE_NAME}Targets
         ${PACKAGE_LOCATION})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    install(FILES $<TARGET_PDB_FILE:${target}> 
-        DESTINATION 
+    install(FILES $<TARGET_PDB_FILE:${target}>
+        DESTINATION
             ${QSK_INSTALL_LIBS} OPTIONAL)
 endif()

--- a/src/common/QskArcMetrics.cpp
+++ b/src/common/QskArcMetrics.cpp
@@ -98,10 +98,13 @@ static inline QPainterPath qskOrthogonalPath(
     return stroker.createStroke( arcPath );
 }
 
+#ifndef __qskInterpolated
+#define __qskInterpolated
 static inline qreal qskInterpolated( qreal from, qreal to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
 }
+#endif
 
 static inline qreal qskEffectiveThickness( qreal radius, qreal percentage )
 {

--- a/src/common/QskBoxShapeMetrics.cpp
+++ b/src/common/QskBoxShapeMetrics.cpp
@@ -27,10 +27,13 @@ static void qskRegisterBoxShapeMetrics()
 
 Q_CONSTRUCTOR_FUNCTION( qskRegisterBoxShapeMetrics )
 
+namespace QskBoxShapeMetricsImpl
+{
 static inline QSizeF qskInterpolatedSize(
     const QSizeF& from, const QSizeF& to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
+}
 }
 
 static inline qreal qskAbsoluted( qreal length, qreal percentage )
@@ -150,10 +153,10 @@ QskBoxShapeMetrics QskBoxShapeMetrics::interpolated(
         return to;
 
     return QskBoxShapeMetrics(
-        qskInterpolatedSize( m_radii[ 0 ], to.m_radii[ 0 ], ratio ),
-        qskInterpolatedSize( m_radii[ 1 ], to.m_radii[ 1 ], ratio ),
-        qskInterpolatedSize( m_radii[ 2 ], to.m_radii[ 2 ], ratio ),
-        qskInterpolatedSize( m_radii[ 3 ], to.m_radii[ 3 ], ratio ),
+        QskBoxShapeMetricsImpl::qskInterpolatedSize( m_radii[ 0 ], to.m_radii[ 0 ], ratio ),
+        QskBoxShapeMetricsImpl::qskInterpolatedSize( m_radii[ 1 ], to.m_radii[ 1 ], ratio ),
+        QskBoxShapeMetricsImpl::qskInterpolatedSize( m_radii[ 2 ], to.m_radii[ 2 ], ratio ),
+        QskBoxShapeMetricsImpl::qskInterpolatedSize( m_radii[ 3 ], to.m_radii[ 3 ], ratio ),
         to.m_sizeMode, to.m_scalingMode );
 }
 

--- a/src/common/QskGraduationMetrics.cpp
+++ b/src/common/QskGraduationMetrics.cpp
@@ -17,11 +17,13 @@ static void qskRegisterGraduationMetrics()
 
 Q_CONSTRUCTOR_FUNCTION( qskRegisterGraduationMetrics )
 
+#ifndef __qskInterpolated
+#define __qskInterpolated
 static inline qreal qskInterpolated( qreal from, qreal to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
 }
-
+#endif
 QskGraduationMetrics QskGraduationMetrics::interpolated(
     const QskGraduationMetrics& to, const qreal ratio ) const noexcept
 {

--- a/src/common/QskMargins.cpp
+++ b/src/common/QskMargins.cpp
@@ -23,10 +23,13 @@ static void qskRegisterMargins()
 
 Q_CONSTRUCTOR_FUNCTION( qskRegisterMargins )
 
+#ifndef __qskInterpolated
+#define __qskInterpolated
 static inline qreal qskInterpolated( qreal from, qreal to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
 }
+#endif
 
 static inline QskMargins qskInterpolateMargins(
     const QskMargins& m1, const QskMargins& m2, qreal progress )

--- a/src/common/QskShadowMetrics.cpp
+++ b/src/common/QskShadowMetrics.cpp
@@ -20,10 +20,13 @@ static void qskRegisterShadowMetrics()
 
 Q_CONSTRUCTOR_FUNCTION( qskRegisterShadowMetrics )
 
+#ifndef __qskInterpolated
+#define __qskInterpolated
 static inline qreal qskInterpolated( qreal from, qreal to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
 }
+#endif
 
 static inline qreal qskToAbsolute( qreal length, qreal percentage )
 {

--- a/src/common/QskStippleMetrics.cpp
+++ b/src/common/QskStippleMetrics.cpp
@@ -37,10 +37,13 @@ QVector< qreal > qskDashPattern( Qt::PenStyle style )
     return pattern[ style ];
 }
 
+#ifndef __qskInterpolated
+#define __qskInterpolated
 static inline qreal qskInterpolated( qreal from, qreal to, qreal ratio )
 {
     return from + ( to - from ) * ratio;
 }
+#endif
 
 static inline QVector< qreal > qskInterpolatedSpaces(
     const QVector< qreal >& pattern, qreal progress )

--- a/src/controls/QskControl.cpp
+++ b/src/controls/QskControl.cpp
@@ -26,11 +26,14 @@ QSK_SYSTEM_STATE( QskControl, Disabled, QskAspect::FirstSystemState )
 QSK_SYSTEM_STATE( QskControl, Hovered, QskAspect::LastSystemState >> 1 )
 QSK_SYSTEM_STATE( QskControl, Focused, QskAspect::LastSystemState )
 
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
 static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 static inline bool qskMaybeGesture( QQuickItem* item,
     const QQuickItem* child, const QEvent* event )

--- a/src/controls/QskControlPrivate.cpp
+++ b/src/controls/QskControlPrivate.cpp
@@ -10,11 +10,14 @@
 #include "QskWindow.h"
 #include "QskEvent.h"
 
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
 static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 extern bool qskInheritLocale( QskWindow*, const QLocale& );
 

--- a/src/controls/QskItem.cpp
+++ b/src/controls/QskItem.cpp
@@ -39,11 +39,14 @@ QSK_QT_PRIVATE_END
 
 #include <unordered_set>
 
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
 static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 static inline void qskApplyUpdateFlags(
     QskItem::UpdateFlags flags, QskItem* item )

--- a/src/controls/QskItemPrivate.cpp
+++ b/src/controls/QskItemPrivate.cpp
@@ -7,11 +7,14 @@
 #include "QskTreeNode.h"
 #include "QskSetup.h"
 
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
 static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 QskItemPrivate::QskItemPrivate()
     : updateFlags( QskSetup::updateFlags() )

--- a/src/controls/QskProgressBarSkinlet.cpp
+++ b/src/controls/QskProgressBarSkinlet.cpp
@@ -11,8 +11,6 @@
 #include <qeasingcurve.h>
 #include <cmath>
 
-using Q = QskProgressBar;
-
 namespace
 {
     QskIntervalF qskFillInterval( const QskProgressIndicator* indicator )
@@ -66,11 +64,11 @@ QRectF QskProgressBarSkinlet::subControlRect(
     const QskSkinnable* skinnable, const QRectF& contentsRect,
     QskAspect::Subcontrol subControl ) const
 {
-    const auto bar = static_cast< const Q* >( skinnable );
+    const auto bar = static_cast< const QskProgressBar* >( skinnable );
 
-    if( subControl == Q::Groove )
+    if( subControl == QskProgressBar::Groove )
     {
-        const auto grooveSize = bar->metric( Q::Groove | QskAspect::Size );
+        const auto grooveSize = bar->metric( QskProgressBar::Groove | QskAspect::Size );
 
         auto rect = contentsRect;
         if ( bar->orientation() == Qt::Horizontal )
@@ -87,7 +85,7 @@ QRectF QskProgressBarSkinlet::subControlRect(
         return rect;
     }
 
-    if( subControl == Q::Fill )
+    if( subControl == QskProgressBar::Fill )
     {
         return barRect( bar );
     }
@@ -98,15 +96,15 @@ QRectF QskProgressBarSkinlet::subControlRect(
 QSGNode* QskProgressBarSkinlet::updateGrooveNode(
     const QskProgressIndicator* indicator, QSGNode* node ) const
 {
-    return updateBoxNode( indicator, node, Q::Groove );
+    return updateBoxNode( indicator, node, QskProgressBar::Groove );
 }
 
 QSGNode* QskProgressBarSkinlet::updateFillNode(
     const QskProgressIndicator* indicator, QSGNode* node ) const
 {
-    const auto bar = static_cast< const Q* >( indicator );
+    const auto bar = static_cast< const QskProgressBar* >( indicator );
 
-    const auto subControl = Q::Fill;
+    const auto subControl = QskProgressBar::Fill;
 
     const auto rect = indicator->subControlRect( subControl );
     if ( rect.isEmpty() )
@@ -146,11 +144,11 @@ QSGNode* QskProgressBarSkinlet::updateFillNode(
     return updateBoxNode( indicator, node, rect, gradient, subControl );
 }
 
-QRectF QskProgressBarSkinlet::barRect( const Q* bar ) const
+QRectF QskProgressBarSkinlet::barRect( const QskProgressBar* bar ) const
 {
-    const auto subControl = Q::Groove;
+    const auto subControl = QskProgressBar::Groove;
 
-    const auto barSize = bar->metric( Q::Fill | QskAspect::Size );
+    const auto barSize = bar->metric( QskProgressBar::Fill | QskAspect::Size );
     auto rect = bar->subControlRect( subControl );
 
     if ( bar->orientation() == Qt::Horizontal )
@@ -197,7 +195,7 @@ QSizeF QskProgressBarSkinlet::sizeHint( const QskSkinnable* skinnable,
     if ( which != Qt::PreferredSize )
         return QSizeF();
 
-    const auto bar = static_cast< const Q* >( skinnable );
+    const auto bar = static_cast< const QskProgressBar* >( skinnable );
 
     const auto extent = bar->extent();
 

--- a/src/controls/QskProgressRingSkinlet.cpp
+++ b/src/controls/QskProgressRingSkinlet.cpp
@@ -8,8 +8,6 @@
 #include "QskProgressRing.h"
 #include "QskIntervalF.h"
 
-using Q = QskProgressRing;
-
 QskProgressRingSkinlet::QskProgressRingSkinlet( QskSkin* skin )
     : Inherited( skin )
 {
@@ -23,7 +21,7 @@ QRectF QskProgressRingSkinlet::subControlRect(
     const QskSkinnable* skinnable, const QRectF& contentsRect,
     QskAspect::Subcontrol subControl ) const
 {
-    if( subControl == Q::Groove || subControl == Q::Fill )
+    if( subControl == QskProgressRing::Groove || subControl == QskProgressRing::Fill )
         return contentsRect;
 
     return Inherited::subControlRect( skinnable, contentsRect, subControl );
@@ -32,15 +30,15 @@ QRectF QskProgressRingSkinlet::subControlRect(
 QSGNode* QskProgressRingSkinlet::updateGrooveNode(
     const QskProgressIndicator* indicator, QSGNode* node ) const
 {
-    return updateArcNode( indicator, node, Q::Groove );
+    return updateArcNode( indicator, node, QskProgressRing::Groove );
 }
 
 QSGNode* QskProgressRingSkinlet::updateFillNode(
     const QskProgressIndicator* indicator, QSGNode* node ) const
 {
-    const auto ring = static_cast< const Q* >( indicator );
+    const auto ring = static_cast< const QskProgressRing* >( indicator );
 
-    const auto subControl = Q::Fill;
+    const auto subControl = QskProgressRing::Fill;
 
     const auto rect = ring->subControlRect( subControl );
     if ( rect.isEmpty() )
@@ -79,8 +77,8 @@ QSizeF QskProgressRingSkinlet::sizeHint( const QskSkinnable* skinnable,
     if ( which != Qt::PreferredSize )
         return QSizeF();
 
-    auto hint = skinnable->strutSizeHint( Q::Fill );
-    hint = hint.expandedTo( skinnable->strutSizeHint( Q::Groove ) );
+    auto hint = skinnable->strutSizeHint( QskProgressRing::Fill );
+    hint = hint.expandedTo( skinnable->strutSizeHint( QskProgressRing::Groove ) );
 
     if ( !constraint.isEmpty() )
     {
@@ -88,7 +86,7 @@ QSizeF QskProgressRingSkinlet::sizeHint( const QskSkinnable* skinnable,
 
         if ( constraint.width() >= 0.0 )
             hint.setHeight( constraint.width() / aspectRatio );
-        else 
+        else
             hint.setWidth( constraint.height() * aspectRatio );
     }
 

--- a/src/controls/QskWindow.cpp
+++ b/src/controls/QskWindow.cpp
@@ -40,11 +40,14 @@ extern void qskInheritLocale( QObject*, const QLocale& );
 static void qskResolveLocale( QskWindow* );
 static bool qskEnforcedSkin = false;
 
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
 static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 static QQuickItem* qskDefaultFocusItem( QQuickWindow* window )
 {

--- a/src/dialogs/QskDialogButtonBox.cpp
+++ b/src/dialogs/QskDialogButtonBox.cpp
@@ -20,11 +20,14 @@
 
 QSK_SUBCONTROL( QskDialogButtonBox, Panel )
 
-static void qskSendEventTo( QObject* object, QEvent::Type type )
+#ifndef __qskSendEventTo
+#define __qskSendEventTo
+static inline void qskSendEventTo( QObject* object, QEvent::Type type )
 {
     QEvent event( type );
     QCoreApplication::sendEvent( object, &event );
 }
+#endif
 
 namespace
 {

--- a/src/dialogs/QskMessageSubWindow.cpp
+++ b/src/dialogs/QskMessageSubWindow.cpp
@@ -6,7 +6,7 @@
 #include "QskMessageSubWindow.h"
 #include "QskTextLabel.h"
 
-namespace
+namespace QskMessageSubWindowImpl
 {
     class TextLabel final : public QskTextLabel
     {
@@ -28,7 +28,7 @@ namespace
 QskMessageSubWindow::QskMessageSubWindow( QQuickItem* parent )
     : Inherited( parent )
 {
-    auto label = new TextLabel();
+    auto label = new QskMessageSubWindowImpl::TextLabel();
 
     connect( label, &QskTextLabel::textChanged,
         this, &QskMessageSubWindow::textChanged );

--- a/src/dialogs/QskMessageWindow.cpp
+++ b/src/dialogs/QskMessageWindow.cpp
@@ -7,7 +7,7 @@
 #include "QskTextLabel.h"
 #include "QskTextOptions.h"
 
-namespace
+namespace QskMessageWindowImpl
 {
     class TextLabel final : public QskTextLabel
     {
@@ -42,7 +42,7 @@ QskMessageWindow::QskMessageWindow( QWindow* parent )
     setFlags( Qt::Dialog | Qt::WindowTitleHint |
         Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint );
 
-    m_data->textLabel = new TextLabel( this );
+    m_data->textLabel = new QskMessageWindowImpl::TextLabel( this );
     setDialogContentItem( m_data->textLabel );
 }
 

--- a/src/dialogs/QskSelectionSubWindow.cpp
+++ b/src/dialogs/QskSelectionSubWindow.cpp
@@ -22,7 +22,7 @@ static inline const QskSimpleListBox* qskListBox(
     return qobject_cast< QskSimpleListBox* >( subWindow->contentItem() );
 }
 
-namespace
+namespace QskSelectionSubWindowImpl
 {
     class ListBox final : public QskSimpleListBox
     {
@@ -46,7 +46,7 @@ namespace
 QskSelectionSubWindow::QskSelectionSubWindow( QQuickItem* parent )
     : Inherited( parent )
 {
-    auto listBox = new ListBox( this );
+    auto listBox = new QskSelectionSubWindowImpl::ListBox( this );
 #if 1
     listBox->setPreferredSize( 500, 500 );
 #endif

--- a/src/dialogs/QskSelectionWindow.cpp
+++ b/src/dialogs/QskSelectionWindow.cpp
@@ -22,7 +22,7 @@ static inline const QskSimpleListBox* qskListBox(
     return qobject_cast< QskSimpleListBox* >( window->dialogContentItem() );
 }
 
-namespace
+namespace QskSelectionWindowImpl
 {
     class ListBox final : public QskSimpleListBox
     {
@@ -49,7 +49,7 @@ QskSelectionWindow::QskSelectionWindow( QWindow* parent )
     setFlags( Qt::Dialog | Qt::WindowTitleHint |
         Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint );
 
-    auto listBox = new ListBox( this );
+    auto listBox = new QskSelectionWindowImpl::ListBox( this );
 #if 1
     listBox->setPreferredSize( 500, 500 );
 #endif

--- a/src/inputpanel/QskInputPredictionBar.cpp
+++ b/src/inputpanel/QskInputPredictionBar.cpp
@@ -15,7 +15,7 @@ QSK_SUBCONTROL( QskInputPredictionBar, Panel )
 QSK_SUBCONTROL( QskInputPredictionBar, ButtonPanel )
 QSK_SUBCONTROL( QskInputPredictionBar, ButtonText )
 
-namespace
+namespace QskInputPredictionBarImpl
 {
     class Button final : public QskPushButton
     {
@@ -78,7 +78,7 @@ QskInputPredictionBar::QskInputPredictionBar( QQuickItem* parent )
 
     for ( int i = 0; i < m_data->buttonCount; i++ )
     {
-        auto button = new Button( m_data->layoutBox );
+        auto button = new QskInputPredictionBarImpl::Button( m_data->layoutBox );
         button->setVisible( false );
         button->setSizePolicy( Qt::Horizontal, QskSizePolicy::Maximum );
 

--- a/src/inputpanel/QskVirtualKeyboard.cpp
+++ b/src/inputpanel/QskVirtualKeyboard.cpp
@@ -10,7 +10,7 @@
 #include <qset.h>
 #include <qstylehints.h>
 
-namespace
+namespace QskVirtualKeyboardImpl
 {
     class Button : public QskPushButton
     {
@@ -64,7 +64,7 @@ class QskVirtualKeyboard::PrivateData
     const QskVirtualKeyboardLayouts::Layout* currentLayout = nullptr;
     QskVirtualKeyboard::Mode mode = QskVirtualKeyboard::LowercaseMode;
 
-    QVector< Button* > keyButtons;
+    QVector< QskVirtualKeyboardImpl::Button* > keyButtons;
     QSet< int > keyCodes;
 };
 
@@ -288,7 +288,7 @@ void QskVirtualKeyboard::updateLayout() // ### fill keyCodes here
                     const QRectF rect( xPos, yPos, keyWidth, keyHeight );
 
                     button->setGeometry( rect );
-                    button->setAutoRepeat( qskIsAutorepeat( key ) );
+                    button->setAutoRepeat( QskVirtualKeyboardImpl::qskIsAutorepeat( key ) );
                     button->setKey( key );
                     button->setText( textForKey( key ) );
 
@@ -373,7 +373,7 @@ void QskVirtualKeyboard::ensureButtons()
 
             if( index >= m_data->keyButtons.size() )
             {
-                auto button = new Button( this );
+                auto button = new QskVirtualKeyboardImpl::Button( this );
                 button->installEventFilter( this );
 
                 button->setAutoRepeat( false );
@@ -397,7 +397,7 @@ void QskVirtualKeyboard::ensureButtons()
 
 void QskVirtualKeyboard::buttonPressed()
 {
-    const auto button = static_cast< const Button* >( sender() );
+    const auto button = static_cast< const QskVirtualKeyboardImpl::Button* >( sender() );
     if ( button == nullptr )
         return;
 

--- a/src/layouts/QskGridBox.cpp
+++ b/src/layouts/QskGridBox.cpp
@@ -10,6 +10,8 @@
 #include <qdebug.h>
 #include <algorithm>
 
+#ifndef __qskSetItemActive
+#define __qskSetItemActive
 static void qskSetItemActive( QObject* receiver, const QQuickItem* item, bool on )
 {
     /*
@@ -38,6 +40,7 @@ static void qskSetItemActive( QObject* receiver, const QQuickItem* item, bool on
         QObject::disconnect( item, &QQuickItem::implicitHeightChanged, receiver, nullptr );
     }
 }
+#endif
 
 static void qskUpdateFocusChain(
     QskGridBox* box, const QskGridLayoutEngine* engine,

--- a/src/layouts/QskLinearBox.cpp
+++ b/src/layouts/QskLinearBox.cpp
@@ -8,6 +8,8 @@
 #include "QskEvent.h"
 #include "QskQuick.h"
 
+#ifndef __qskSetItemActive
+#define __qskSetItemActive
 static void qskSetItemActive( QObject* receiver, const QQuickItem* item, bool on )
 {
     /*
@@ -36,6 +38,7 @@ static void qskSetItemActive( QObject* receiver, const QQuickItem* item, bool on
         QObject::disconnect( item, &QQuickItem::implicitHeightChanged, receiver, nullptr );
     }
 }
+#endif
 
 class QskLinearBox::PrivateData
 {

--- a/src/nodes/QskArcRenderer.cpp
+++ b/src/nodes/QskArcRenderer.cpp
@@ -12,19 +12,25 @@
 
 #include <qsggeometry.h>
 
+#ifndef __qskAllocateLines
+#define __qskAllocateLines
 static inline QskVertex::Line* qskAllocateLines(
     QSGGeometry& geometry, int lineCount )
 {
     geometry.allocate( 2 * lineCount ); // 2 points per line
     return reinterpret_cast< QskVertex::Line* >( geometry.vertexData() );
 }
+#endif
 
+#ifndef __qskAllocateColoredLines
+#define __qskAllocateColoredLines
 static inline QskVertex::ColoredLine* qskAllocateColoredLines(
     QSGGeometry& geometry, int lineCount )
 {
     geometry.allocate( 2 * lineCount ); // 2 points per line
     return reinterpret_cast< QskVertex::ColoredLine* >( geometry.vertexData() );
 }
+#endif
 
 namespace
 {

--- a/src/nodes/QskBoxNode.cpp
+++ b/src/nodes/QskBoxNode.cpp
@@ -16,7 +16,7 @@
 #include "QskBoxShapeMetrics.h"
 #include "QskRgbValue.h"
 
-namespace
+namespace QskBoxNodeImpl
 {
     enum Role
     {
@@ -25,31 +25,31 @@ namespace
         BoxRole,
         FillRole
     };
-}
 
-static void qskUpdateChildren( QSGNode* parentNode, quint8 role, QSGNode* node )
-{
-    static const QVector< quint8 > roles =
-        { ShadowRole, ShadowFillRole, BoxRole, FillRole };
-
-    auto oldNode = QskSGNode::findChildNode( parentNode, role );
-    QskSGNode::replaceChildNode( roles, role, parentNode, oldNode, node );
-}
-
-template< typename Node >
-static inline Node* qskNode( QSGNode* parentNode, quint8 role )
-{
-    using namespace QskSGNode;
-
-    auto node = static_cast< Node* > ( findChildNode( parentNode, role ) );
-
-    if ( node == nullptr )
+    static void qskUpdateChildren( QSGNode* parentNode, quint8 role, QSGNode* node )
     {
-        node = new Node();
-        setNodeRole( node, role );
+        static const QVector< quint8 > roles =
+            { QskBoxNodeImpl::ShadowRole, QskBoxNodeImpl::ShadowFillRole, QskBoxNodeImpl::BoxRole, QskBoxNodeImpl::BoxRole };
+
+        auto oldNode = QskSGNode::findChildNode( parentNode, role );
+        QskSGNode::replaceChildNode( roles, role, parentNode, oldNode, node );
     }
 
-    return node;
+    template< typename Node >
+    static inline Node* qskNode( QSGNode* parentNode, quint8 role )
+    {
+        using namespace QskSGNode;
+
+        auto node = static_cast< Node* > ( findChildNode( parentNode, role ) );
+
+        if ( node == nullptr )
+        {
+            node = new Node();
+            setNodeRole( node, role );
+        }
+
+        return node;
+    }
 }
 
 QskBoxNode::QskBoxNode()
@@ -99,13 +99,13 @@ void QskBoxNode::updateNode( const QQuickWindow* window, const QRectF& rect,
             if ( shadow.blurRadius() <= 0.0 )
             {
                 // QskBoxRectangleNode allows scene graph batching
-                shadowFillNode = qskNode< QskBoxRectangleNode >( this, ShadowFillRole );
+                shadowFillNode = QskBoxNodeImpl::qskNode< QskBoxRectangleNode >( this, QskBoxNodeImpl::ShadowFillRole );
                 shadowFillNode->updateFilling( window,
                     shadowRect, shadowShape, shadowColor );
             }
             else
             {
-                shadowNode = qskNode< QskBoxShadowNode >( this, ShadowRole );
+                shadowNode = QskBoxNodeImpl::qskNode< QskBoxShadowNode >( this, QskBoxNodeImpl::ShadowRole );
                 shadowNode->setShadowData( shadowRect,
                     shadowShape, shadow.blurRadius(), shadowColor );
             }
@@ -113,7 +113,7 @@ void QskBoxNode::updateNode( const QQuickWindow* window, const QRectF& rect,
 
         if ( hasBorder || hasFilling )
         {
-            rectNode = qskNode< QskBoxRectangleNode >( this, BoxRole );
+            rectNode = QskBoxNodeImpl::qskNode< QskBoxRectangleNode >( this, QskBoxNodeImpl::BoxRole );
 
             if ( hasBorder && hasFilling )
             {
@@ -121,7 +121,7 @@ void QskBoxNode::updateNode( const QQuickWindow* window, const QRectF& rect,
                     && QskBoxRectangleNode::isCombinedGeometrySupported( gradient );
 
                 if ( !doCombine )
-                    fillNode = qskNode< QskBoxRectangleNode >( this, FillRole );
+                    fillNode = QskBoxNodeImpl::qskNode< QskBoxRectangleNode >( this, QskBoxNodeImpl::BoxRole );
             }
 
             if ( fillNode )
@@ -140,8 +140,8 @@ void QskBoxNode::updateNode( const QQuickWindow* window, const QRectF& rect,
         }
     }
 
-    qskUpdateChildren( this, ShadowRole, shadowNode );
-    qskUpdateChildren( this, ShadowFillRole, shadowFillNode );
-    qskUpdateChildren( this, BoxRole, rectNode );
-    qskUpdateChildren( this, FillRole, fillNode );
+    QskBoxNodeImpl::qskUpdateChildren( this, QskBoxNodeImpl::ShadowRole, shadowNode );
+    QskBoxNodeImpl::qskUpdateChildren( this, QskBoxNodeImpl::ShadowFillRole, shadowFillNode );
+    QskBoxNodeImpl::qskUpdateChildren( this, QskBoxNodeImpl::BoxRole, rectNode );
+    QskBoxNodeImpl::qskUpdateChildren( this, QskBoxNodeImpl::BoxRole, fillNode );
 }

--- a/src/nodes/QskBoxRenderer.cpp
+++ b/src/nodes/QskBoxRenderer.cpp
@@ -17,19 +17,25 @@
 
 #include <qsggeometry.h>
 
+#ifndef __qskAllocateLines
+#define __qskAllocateLines
 static inline QskVertex::Line* qskAllocateLines(
     QSGGeometry& geometry, int lineCount )
 {
     geometry.allocate( 2 * lineCount ); // 2 points per line
     return reinterpret_cast< QskVertex::Line* >( geometry.vertexData() );
 }
+#endif
 
+#ifndef __qskAllocateColoredLines
+#define __qskAllocateColoredLines
 static inline QskVertex::ColoredLine* qskAllocateColoredLines(
     QSGGeometry& geometry, int lineCount )
 {
     geometry.allocate( 2 * lineCount ); // 2 points per line
     return reinterpret_cast< QskVertex::ColoredLine* >( geometry.vertexData() );
 }
+#endif
 
 static inline QskGradient qskEffectiveGradient(
     const QRectF& rect, const QskGradient& gradient )

--- a/src/nodes/QskClipNode.cpp
+++ b/src/nodes/QskClipNode.cpp
@@ -40,12 +40,15 @@ static inline void qskSetBoundingRect( QSGClipNode* node, const QRectF& rect )
     node->setClipRect( rect );
 }
 
+#ifndef __qskAllocateLines
+#define __qskAllocateLines
 static inline QskVertex::Line* qskAllocateLines(
     QSGGeometry& geometry, int lineCount )
 {
     geometry.allocate( 2 * lineCount ); // 2 points per line
     return reinterpret_cast< QskVertex::Line* >( geometry.vertexData() );
 }
+#endif
 
 QskClipNode::QskClipNode()
     : m_hash( 0 )

--- a/src/nodes/QskSceneTexture.cpp
+++ b/src/nodes/QskSceneTexture.cpp
@@ -34,22 +34,22 @@ static int qskRenderOrderCompare( const QSGNode* rootNode,
 {
     if ( rootNode == node1 )
         return 1;
-            
+
     if ( rootNode == node2 )
         return -1;
 
     for ( auto node = rootNode->firstChild();
         node != nullptr; node = node->nextSibling() )
-    {   
+    {
         const auto ret = qskRenderOrderCompare( node, node1, node2 );
-        if ( ret ) 
+        if ( ret )
             return ret;
-    }       
-    
-    return 0;
-}   
+    }
 
-namespace
+    return 0;
+}
+
+namespace QskSceneTextureImpl
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     inline QSGRendererInterface::RenderMode contextRenderMode(
@@ -244,7 +244,7 @@ namespace
             the texture has already  been updated. In these situations we
             update the texture twice. Not so good ...
          */
-        if ( qskRenderOrderCompare( rootNode(), node, m_finalNode ) > 0 ) 
+        if ( qskRenderOrderCompare( rootNode(), node, m_finalNode ) > 0 )
         {
             // triggering QSGRenderer::sceneGraphChanged signals
             Inherited::nodeChanged( node, state );
@@ -389,7 +389,7 @@ class QskSceneTexturePrivate final : public QSGTexturePrivate
     QRectF rect;
     const qreal devicePixelRatio;
 
-    Renderer* renderer = nullptr;
+    QskSceneTextureImpl::Renderer* renderer = nullptr;
     QSGDefaultRenderContext* context = nullptr;
 };
 
@@ -419,7 +419,7 @@ void QskSceneTexture::render( const QSGRootNode* rootNode,
 
     if ( d->renderer == nullptr )
     {
-        d->renderer = new Renderer( this, d->context );
+        d->renderer = new QskSceneTextureImpl::Renderer( this, d->context );
         d->renderer->setDevicePixelRatio( d->devicePixelRatio );
     }
 

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -39,4 +39,3 @@ if(ENABLE_ENSURE_SKINS)
 endif()
 
 set_target_properties(${target} PROPERTIES FOLDER libs)
-set_target_properties(${target} PROPERTIES UNITY_BUILD OFF)

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -39,3 +39,4 @@ if(ENABLE_ENSURE_SKINS)
 endif()
 
 set_target_properties(${target} PROPERTIES FOLDER libs)
+set_target_properties(${target} PROPERTIES UNITY_BUILD OFF)


### PR DESCRIPTION
**What**

Enable [`CMAKE_UNITY_BUILD`](https://cmake.org/cmake/help/latest/variable/CMAKE_UNITY_BUILD.html) accelerating total build time from 50s to 36s. 😮 

This enables unity builds globally ( :warning: not recommended )

```cmake
set(CMAKE_UNITY_BUILD ON)
```

This enables unity builds on a specific target
```cmake
set_target_properties(${target} PROPERTIES UNITY_BUILD ON)
```

This excludes generated moc_* files from it

```cmake
if(BUILD_UNITY)
    file(GLOB_RECURSE MOC_FILES
        ${CMAKE_CURRENT_BINARY_DIR}/moc_*.cpp
    )

    set_source_files_properties(${MOC_FILES} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
endif()
```